### PR TITLE
Check all session and cursor aliases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="py-find-injection",
-    version="0.1.1",
+    version="0.1.2",
     author="James Brown",
     author_email="jbrown@uber.com",
     url="https://github.com/uber/py-find-injection",


### PR DESCRIPTION
Include additional try except to catch IndexErrors for nodes which do not have parents because they are not executing sql queries. 

this py-find-injection will check all functions with the format `*.execute` because session.execute and cursor.execute may not be the only names used - in the case that the code uses aliases. 
